### PR TITLE
improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-!Build/
 .last_cover_stats
 /META.yml
 /META.json
@@ -8,7 +7,7 @@
 *.bs
 
 # Devel::Cover
-cover_db/
+/cover_db/
 
 # Devel::NYTProf
 nytprof.out
@@ -17,12 +16,9 @@ nytprof.out
 /.build/
 
 # Module::Build
-_build/
-Build
-Build.bat
-
-# Module::Install
-inc/
+/_build/
+/Build
+/Build.bat
 
 # ExtUtils::MakeMaker
 /blib/
@@ -36,3 +32,6 @@ inc/
 
 # vim swap files
 .*.swp
+
+/Attribute-Pure-*.tar.gz
+/Attribute-Pure-*/


### PR DESCRIPTION
Anchor some gitignore entries to the root directory so they don't
exclude other files, and add ignores for build directories.

Also remove the ignore for Module::Install since it will never be used
so any files in inc shouldn't be ignored.

Leave the other author tool entries in place, since they could exist via
regeneration in the future.